### PR TITLE
Add docker support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,3 +19,7 @@ serde_json = "1.0.82"
 [build-dependencies]
 copy_to_output = "2.0.0"
 glob = "0.3.0"
+
+[[bin]]
+name = "cosi-db"
+path = "src/main.rs"

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+# https://blog.mgattozzi.dev/caching-rust-docker-builds/
+FROM rust:1.62
+RUN mkdir /mnt/cosi/
+COPY dummy.rs /mnt/cosi/
+COPY Cargo.lock /mnt/cosi/
+COPY Cargo.toml /mnt/cosi/
+RUN sed -i 's|src/main.rs|dummy.rs|' /mnt/cosi/Cargo.toml
+RUN cd /mnt/cosi/ && cargo build --release
+RUN sed -i 's|dummy.rs|src/main.rs|' /mnt/cosi/Cargo.toml
+COPY . /mnt/cosi
+CMD cd /mnt/cosi && cargo run

--- a/README.md
+++ b/README.md
@@ -11,7 +11,16 @@ A database used for capturing ministry and community life within, usually, a chu
 
 ### Docker
 
-Only available on Linux platforms. More info to come!
+Only available on Linux platforms. Windows and Mac, try at your own risk as subnetworking can be inconsistent.
+You should have docker and docker compose plugin installed.
+
+```bash
+docker compose up
+```
+
+Then navigate to `127.0.0.1:8000`.
+
+**Note that docker deployment is useful for testing. However, can be noticeably slow. Docker runs in debug build by default.**
 
 ### Native Install
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,18 +1,18 @@
-# WIP
-# version: '3'
-# services:
-#   cosi-db:
-#     image: rust:latest
-#     environment:
-#       - MONGODB_CONNSTRING=mongodb://cosi_test_db:testdatabasepass@mongodb
-#     ports:
-#       - 3000:3000
-#       - 8000:8000
-#     volumes:
-#       - .:/mnt/cosi
-#     command: bash -c "cd /mnt/cosi && cargo run"
-#   mongodb:
-#     image: mongo:5.0
-#     environment:
-#       - MONGO_INITDB_ROOT_USERNAME=cosi_test_db
-#       - MONGO_INITDB_ROOT_PASSWORD=testdatabasepass
+version: '3'
+services:
+  cosi-db:
+    build: .
+    ports:
+      - 27017:27017
+      - 8000:8000
+    volumes:
+      - .:/mnt/cosi
+    command: bash -c "cd /mnt/cosi && cargo run"
+    network_mode: "host"
+  mongodb:
+    image: mongo:5.0
+    environment:
+      - MONGO_INITDB_ROOT_USERNAME=admin
+      - MONGO_INITDB_ROOT_PASSWORD=admin
+      - MONGO_INITDB_DATABASE=cosi_db
+    network_mode: "host"

--- a/dummy.rs
+++ b/dummy.rs
@@ -1,0 +1,2 @@
+//  Stub for container generation.
+fn main() {}

--- a/src/cosi_db/connection.rs
+++ b/src/cosi_db/connection.rs
@@ -7,6 +7,7 @@ pub struct CosiDBConfigs {
     pub ip: String,
     pub port: String,
     pub db_name: String,
+    pub auth_src: String,
 }
 
 impl Default for CosiDBConfigs {
@@ -15,6 +16,7 @@ impl Default for CosiDBConfigs {
             ip: "localhost".to_string(),
             port: "27017".to_string(),
             db_name: "cosi_db".to_string(),
+            auth_src: "admin".to_string(),
         }
     }
 }
@@ -42,8 +44,8 @@ impl MongoConnection for CosiDB {
         let c = config.unwrap_or_default();
 
         let mut client_options = ClientOptions::parse(format!(
-            "mongodb://{}:{}@{}:{}/{}",
-            user, pass, c.ip, c.port, c.db_name
+            "mongodb://{}:{}@{}:{}/{}?authSource={}",
+            user, pass, c.ip, c.port, c.db_name, c.auth_src
         ))
         .await?;
 


### PR DESCRIPTION
Adds docker support using `docker compose`. Tested on Arch Linux. Uses `--net=host` to make it easier for users to test locally.