### PR TITLE
Add pagination/performance tests + skeleton for household tests

### DIFF
--- a/tests/household.test.js
+++ b/tests/household.test.js
@@ -1,0 +1,36 @@
+import request from 'supertest';
+
+import { ALL_PAGEABLE_ENDPOINTS, ALL_GEN_ENDPOINTS } from "./endpoints.js";
+
+// Basic helpers
+function cosi_request() {
+    return request("127.0.0.1:8000");
+}
+
+function expectKeys(json_data, keys) {
+    expect(Object.keys(json_data)).toEqual(keys);
+}
+
+// Test setup
+beforeAll(async ()=> {
+    // Before tests begin, populate table with values.
+    let total_data_points_per_table = 200;
+    for (let endpoints of ALL_GEN_ENDPOINTS) {
+        let response = await cosi_request().get(`/${endpoints}/${total_data_points_per_table}`)
+                                           .expect(200)
+                                           .expect("Content-Type", /json/);
+
+        let json_data = JSON.parse(response.text);
+        expectKeys(json_data, ["total"]);
+        expect(json_data["total"]).toBe(total_data_points_per_table)
+    }
+});
+const endpoint = "get_household";
+
+// Testing
+describe("Test Root", () => {
+    test("/ GET", async () => {
+        cosi_request().get(`/${endpoint}`).expect(200).expect("Content-Type", /json/);
+    })
+});
+

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -2,6 +2,8 @@ import request from 'supertest';
 
 import { ALL_PAGEABLE_ENDPOINTS, ALL_GEN_ENDPOINTS } from "./endpoints.js";
 
+var total_datapoints_per_table = 200;
+
 // Basic helpers
 function cosi_request() {
     return request("127.0.0.1:8000");
@@ -14,15 +16,14 @@ function expectKeys(json_data, keys) {
 // Test setup
 beforeAll(async ()=> {
     // Before tests begin, populate table with values.
-    let total_data_points_per_table = 200;
     for (let endpoints of ALL_GEN_ENDPOINTS) {
-        let response = await cosi_request().get(`/${endpoints}/${total_data_points_per_table}`)
+        let response = await cosi_request().get(`/${endpoints}/${total_datapoints_per_table}`)
                                            .expect(200)
                                            .expect("Content-Type", /json/);
 
         let json_data = JSON.parse(response.text);
         expectKeys(json_data, ["total"]);
-        expect(json_data["total"]).toBe(total_data_points_per_table)
+        expect(json_data["total"]).toBe(total_datapoints_per_table)
     }
 });
 
@@ -55,6 +56,55 @@ describe("Verify Getters", () => {
             let json_data = JSON.parse(response.text);
             expectKeys(json_data, return_keys);
             expect(Object.keys(json_data["data"]).length).toBe(max_datapoints);
+        });
+
+        test(`/${endpoint} Empty page load`, async() => {
+            const all_data = await cosi_request()
+                                    .get(`/${endpoint}`)
+                                    .expect(200)
+                                    .query({page: Number.MAX_SAFE_INTEGER})
+                                    .expect("Content-Type", /json/);
+            let json_data = JSON.parse(all_data.text);
+            expect(Object.keys(json_data["data"]).length).toBe(0);
+        });
+
+        test(`/${endpoint} Invalid page load`, async() => {
+            const fake_pages = ["cosi", "-1", "!@#$%^&*()-_+=`"];
+            for (const page of fake_pages){
+                const all_data = await cosi_request()
+                                    .get(`/${endpoint}`)
+                                    .query({page: `${page}`})
+                                    .expect(200)
+                                    .expect("Content-Type", /json/);
+                let json_data = JSON.parse(all_data.text);
+                expect(json_data["page"]).toBe(0);
+                expect(Object.keys(json_data["data"]).length).toBe(max_datapoints);
+                expect(json_data["total_pages"]).toBe(Math.ceil(total_datapoints_per_table/max_datapoints));
+            }
+        });
+
+        test(`/${endpoint} Correct page count`, async() => {
+            const all_data = await cosi_request()
+                                    .get(`/${endpoint}`)
+                                    .expect(200)
+                                    .expect("Content-Type", /json/);
+            let json_data = JSON.parse(all_data.text);
+            let total_pages = json_data["total_pages"];
+            expect(total_pages).toBe(Math.ceil(total_datapoints_per_table/max_datapoints));
+
+        });
+
+        test(`/${endpoint} load < 100ms`, async() => {
+            // Assert that all tables can load data page in < 100ms
+            let startTime = Date.now();
+            const response = await cosi_request()
+                                    .get(`/${endpoint}`)
+                                    .query({page: 0})
+                                    .expect(200)
+                                    .expect("Content-Type", /json/);
+            let endTime = Date.now();
+            // Date.time returns milliseconds since 01/01/1970
+            expect(endTime - startTime).toBeLessThan(100);
         });
     }
 });

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -115,14 +115,14 @@ describe("Verify Getters", () => {
         });
 
         test(`/${endpoint} load < 100ms`, async() => {
-            // Assert that all tables can load data page in < 100ms
+            // Assert that all tables can load data page in < 350ms
             let start_time = Date.now();
             // Exclude normal 200 and content asserts so they don't impact performance
             const response = await cosi_request()
                                     .get(`/${endpoint}`)
                                     .query({page: 0})
             let end_time = Date.now();
-            expect(end_time - start_time).toBeLessThan(100);
+            expect(end_time - start_time).toBeLessThan(350);
         });
     }
 });


### PR DESCRIPTION
Adds a few additional tests to the main test file to test performance and pagination. Also adds a skeletal household test file because this was originally a branch to do that.