### PR TITLE
Share MongoDB Connections, Add Insert Endpoint, Add Basic DOB Sanitization

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -370,6 +370,7 @@ dependencies = [
  "copy_to_output",
  "futures",
  "glob",
+ "lazy_static",
  "lipsum",
  "mongodb",
  "names",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ paste = "1.0"
 with_builtin_macros = "0.0.3"
 futures = "0.3.21"
 anyhow = "1.0.59"
+lazy_static = "1.4.0"
 
 [build-dependencies]
 copy_to_output = "2.0.0"

--- a/src/cosi_db/controller/api.rs
+++ b/src/cosi_db/controller/api.rs
@@ -11,7 +11,6 @@ use mongodb::{bson::doc, bson::from_document, bson::Bson, options::FindOptions};
 
 // cosi_db
 use crate::cosi_db::controller::common::PaginateData;
-use crate::cosi_db::errors::COSIError;
 use crate::cosi_db::model::common::COSICollection;
 use crate::cosi_db::model::common::Generator;
 

--- a/src/cosi_db/controller/api.rs
+++ b/src/cosi_db/controller/api.rs
@@ -2,29 +2,35 @@
 use serde_json;
 
 // rocket
+use rocket::http::Status;
 use rocket::response::content::RawJson;
+use rocket::response::status::Custom;
 
 // mongo
-use mongodb::{bson::doc, options::FindOptions};
+use mongodb::{bson::doc, bson::from_document, bson::Bson, options::FindOptions};
 
 // cosi_db
 use crate::cosi_db::controller::common::PaginateData;
+use crate::cosi_db::errors::COSIError;
 use crate::cosi_db::model::common::COSICollection;
 use crate::cosi_db::model::common::Generator;
 
-use crate::{generate_generators, generate_pageable_getter};
+use crate::{generate_generators, generate_pageable_getter, generate_pageable_inserter};
 
 // Address
 use crate::cosi_db::model::address::{Address, AddressForm};
 generate_generators! { Address }
 generate_pageable_getter! { Address }
+generate_pageable_inserter! { Address }
 
 // Person
 use crate::cosi_db::model::person::{Person, PersonForm};
 generate_generators! { Person }
 generate_pageable_getter! { Person }
+generate_pageable_inserter! { Person }
 
 // Household
 use crate::cosi_db::model::household::{Household, HouseholdForm};
 generate_generators! { Household }
 generate_pageable_getter! { Household }
+generate_pageable_inserter! { Household }

--- a/src/cosi_db/controller/common.rs
+++ b/src/cosi_db/controller/common.rs
@@ -132,7 +132,7 @@ macro_rules! generate_pageable_inserter {
                             Ok(search_obj) => {
                                 // Query any search_queries
                                 let bson_id: Bson = $T::insert_datum(&from_document(search_obj).unwrap(), None).await.unwrap();
-                                Custom(Status::Accepted, RawJson(
+                                Custom(Status::Ok, RawJson(
                                     serde_json::to_string(&bson_id).unwrap()
                                 ))
                             },

--- a/src/cosi_db/controller/dashboard.rs
+++ b/src/cosi_db/controller/dashboard.rs
@@ -5,7 +5,7 @@ use serde::{Deserialize, Serialize};
 // mongo
 use mongodb::bson::doc;
 
-use crate::cosi_db::model::address::{Address, AddressForm};
+use crate::cosi_db::model::address::Address;
 use crate::cosi_db::model::common::COSICollection;
 use crate::cosi_db::model::household::Household;
 use crate::cosi_db::model::person::Person;

--- a/src/cosi_db/model/address.rs
+++ b/src/cosi_db/model/address.rs
@@ -10,7 +10,6 @@ use rocket::form::FromForm;
 
 // cosi_db
 use super::common::{COSICollection, Generator};
-use crate::cosi_db::controller::common::get_connection;
 use crate::cosi_db::errors::COSIResult;
 use crate::cosi_db::model::common::COSIForm;
 

--- a/src/cosi_db/model/address.rs
+++ b/src/cosi_db/model/address.rs
@@ -59,10 +59,6 @@ impl COSICollection<'_, Address, Address, AddressForm> for Address {
     fn get_table_name() -> String {
         return "address".to_string();
     }
-
-    async fn get_collection() -> mongodb::Collection<Address> {
-        get_connection().await.collection::<Address>("address")
-    }
 }
 
 #[async_trait]

--- a/src/cosi_db/model/common.rs
+++ b/src/cosi_db/model/common.rs
@@ -1,11 +1,14 @@
 use async_trait::async_trait;
-use mongodb::{bson::to_document, bson::Bson, bson::Document, options::FindOptions};
+use mongodb::{
+    bson::to_document, bson::Bson, bson::Document, options::FindOptions, options::InsertOneOptions,
+};
 use mongodb::{Collection, Cursor};
 
 use futures::stream::TryStreamExt;
+use std::borrow::Borrow;
 
 use crate::cosi_db::controller::common::get_connection;
-use crate::cosi_db::errors::COSIResult;
+use crate::cosi_db::errors::{COSIError, COSIResult};
 use serde::{de::DeserializeOwned, Serialize};
 
 #[async_trait]
@@ -14,26 +17,45 @@ pub trait Generator<T> {
 }
 
 pub trait COSIForm {
-    fn sanitize(&self) -> COSIResult<Document>
+    // Helper function to convert object to document.
+    // Argument strict decides if all keys must be present.
+    fn convert_to_document(&self, strict: bool) -> COSIResult<Document>
     where
         Self: Serialize,
     {
-        // We only want to search values that are not-null.
-        // Double wrap in Option to allow for searching of nullable.
         let d = to_document(&self).unwrap();
         let mut result = Document::new();
         for v in d {
             match v.1 {
                 Bson::Null => {
-                    continue;
+                    if strict {
+                        return Err(COSIError::msg(format! {"{} key missing.", v.0}));
+                    }
                 }
                 _ => {
                     result.insert(v.0, v.1);
                 }
             }
         }
-
         return Ok(result);
+    }
+
+    fn sanitize_query(&self) -> COSIResult<Document>
+    where
+        Self: Serialize,
+    {
+        // We only want to search values that are not-null.
+        // Double wrap in Option to allow for searching of nullable.
+        self.convert_to_document(false)
+    }
+
+    fn sanitize_insert(&self) -> COSIResult<Document>
+    where
+        Self: Serialize,
+    {
+        // Insert does not allow for non-null.
+        // Double wrap in Option to allow for searching of nullable.
+        self.convert_to_document(true)
     }
 }
 
@@ -78,11 +100,21 @@ where
         return Ok(Self::to_orm(results).await?);
     }
 
+    async fn insert_datum(data: &I, options: Option<InsertOneOptions>) -> COSIResult<Bson> {
+        let col = Self::get_collection().await;
+        let result = col.insert_one(data, options).await?;
+        return Ok(result.inserted_id);
+    }
+
     // Used for processing formdata and input to internal representation.
     // This function technically doesn't need to be here as it is just a softwrapper
     // to into() however it allows for code-readers to understand the relationship between
     // Struct AImpl and Struct AForm.
-    fn convert_form_input(form_data: F) -> COSIResult<Document> {
-        return form_data.sanitize();
+    fn convert_form_query(form_data: F) -> COSIResult<Document> {
+        return form_data.sanitize_query();
+    }
+
+    fn convert_form_insert(form_data: F) -> COSIResult<Document> {
+        return form_data.sanitize_insert();
     }
 }

--- a/src/cosi_db/model/common.rs
+++ b/src/cosi_db/model/common.rs
@@ -5,7 +5,6 @@ use mongodb::{
 use mongodb::{Collection, Cursor};
 
 use futures::stream::TryStreamExt;
-use std::borrow::Borrow;
 
 use crate::cosi_db::controller::common::get_connection;
 use crate::cosi_db::errors::{COSIError, COSIResult};

--- a/src/cosi_db/model/common.rs
+++ b/src/cosi_db/model/common.rs
@@ -46,12 +46,14 @@ where
 {
     fn get_table_name() -> String;
     async fn get_raw_document() -> Collection<Document> {
-        return get_connection()
-            .await
-            .collection::<Document>(&Self::get_table_name());
+        let tname = Self::get_table_name();
+        return get_connection(&tname).await.collection::<Document>(&tname);
     }
 
-    async fn get_collection() -> Collection<I>;
+    async fn get_collection() -> Collection<I> {
+        let tname = Self::get_table_name();
+        get_connection(&tname).await.collection::<I>(&tname)
+    }
 
     async fn to_impl(orm: Vec<T>) -> COSIResult<Vec<I>> {
         // This extra call allows for async side-effects.

--- a/src/cosi_db/model/household.rs
+++ b/src/cosi_db/model/household.rs
@@ -10,7 +10,6 @@ use core::convert::From;
 use rocket::form::FromForm;
 
 // cosi_db
-use crate::cosi_db::controller::common::get_connection;
 use crate::cosi_db::errors::{COSIError, COSIResult};
 
 use crate::cosi_db::model::address::Address;

--- a/src/cosi_db/model/household.rs
+++ b/src/cosi_db/model/household.rs
@@ -67,12 +67,6 @@ impl COSICollection<'_, Household, HouseholdImpl, HouseholdForm> for Household {
         return "household".to_string();
     }
 
-    async fn get_collection() -> mongodb::Collection<HouseholdImpl> {
-        get_connection()
-            .await
-            .collection::<HouseholdImpl>("household")
-    }
-
     async fn to_impl(mut orm: Vec<Household>) -> COSIResult<Vec<HouseholdImpl>> {
         // Slow, fetch results each and every one.
         let collection = Self::get_collection().await;

--- a/src/cosi_db/model/person.rs
+++ b/src/cosi_db/model/person.rs
@@ -10,7 +10,6 @@ use rocket::form::{FromForm, FromFormField};
 
 // cosi_db
 use super::common::{COSICollection, COSIForm, Generator};
-use crate::cosi_db::controller::common::get_connection;
 use crate::cosi_db::errors::{COSIError, COSIResult};
 
 #[derive(Copy, Clone, Debug, FromFormField, Deserialize, Serialize)]

--- a/src/cosi_db/model/person.rs
+++ b/src/cosi_db/model/person.rs
@@ -49,10 +49,6 @@ impl COSICollection<'_, Person, Person, PersonForm> for Person {
     fn get_table_name() -> String {
         return "person".to_string();
     }
-
-    async fn get_collection() -> mongodb::Collection<Person> {
-        get_connection().await.collection::<Person>("person")
-    }
 }
 
 #[async_trait]

--- a/src/main.rs
+++ b/src/main.rs
@@ -11,9 +11,11 @@ pub use ::with_builtin_macros;
 // COSI
 pub mod cosi_db;
 pub mod routes;
+use crate::cosi_db::controller::common::initialize_connections;
 
 #[launch]
 async fn rocket() -> Rocket<Build> {
+    initialize_connections().await;
     let rocket_build = routes::register_route(rocket::build()).attach(Template::fairing());
     rocket_build
 }

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -10,10 +10,13 @@ pub fn register_route(rb: Rocket<Build>) -> Rocket<Build> {
             index,
             generate_person,
             get_person,
+            insert_person,
             generate_address,
             get_address,
+            insert_address,
             generate_household,
             get_household,
+            insert_household,
             search
         ],
     )


### PR DESCRIPTION
* MongoDB Connections are now per-table
  * We may need to tweak this more
  * We need more tests on multi-threaded pings to server to check if we need to increase connections. 
* Adds `insert_xxx` end points.
   * Usage: `insert_xxx?col=x&col=b`
     * Empty strings use: `col=&col_two=c`.
     * Vectors default to empty vector if no specifier is given (rather than empty string.)
   * Errors will return a code of 400: Bad Request with a JSON of `{"err": "error_msg"}`
   * Otherwise returns code 200 with JSON of OID inserted: `{"$oid": <hex_string>}`
* Added `sanitize_insert()` for `COSIForm` which sanitizes the insert results with easier to read error messages.
* Inserts for foreign keys require the object ID, not an inlined object.
   * This forces foreign keys to be valid before we can insert.
   * In the future we can add convenience endpoints where you can inline new foreign objects. (Our framework supports this.)
   