### PR TITLE
Add support for _id export

### DIFF
--- a/public/js/dashboard.js
+++ b/public/js/dashboard.js
@@ -150,7 +150,13 @@ $(document).ready(() => {
                 let row = table[0].insertRow(-1);
 
                 for (let h = 0; h < keys.length; ++h) {
-                    $(row.insertCell(-1)).html(actualData[i][keys[h]]);
+                    let k = keys[h];
+                    if (k == "_id") {
+                        $(row.insertCell(-1)).html(actualData[i][k]["$oid"]);
+                    }
+                    else {
+                        $(row.insertCell(-1)).html(actualData[i][k]);
+                    }
                 }
             }
 

--- a/src/cosi_db/controller/api.rs
+++ b/src/cosi_db/controller/api.rs
@@ -7,7 +7,7 @@ use rocket::response::content::RawJson;
 use rocket::response::status::Custom;
 
 // mongo
-use mongodb::{bson::doc, bson::from_document, bson::Bson, options::FindOptions};
+use mongodb::{bson::doc, bson::from_document, bson::Bson, bson::Document, options::FindOptions};
 
 // cosi_db
 use crate::cosi_db::controller::common::PaginateData;

--- a/src/cosi_db/controller/common.rs
+++ b/src/cosi_db/controller/common.rs
@@ -102,7 +102,8 @@ macro_rules! generate_pageable_getter {
 
                         let search_doc = $T::convert_form_query(search_query).unwrap();
                         // Query any search_queries
-                        let data: Vec<$T> = $T::find_data(Some(search_doc), Some(find_options)).await.unwrap();
+                        // let data: Vec<$T> = $T::find_data(Some(search_doc), Some(find_options)).await.unwrap();
+                        let data: Vec<Document> = $T::find_document(Some(search_doc), Some(find_options)).await.unwrap();
 
                         RawJson(
                             serde_json::to_string(&PaginateData {


### PR DESCRIPTION
Prior to this change, we had not exported "_id" in our get endpoints which made querying by unique values difficult. This change adds a "_id" result.

By default, our framework, Rocket, adds the following format:

```json
{
   "_id": 
   {
      "$oid": "mycustomhex"
   }
}
```

Though we can further process this and remove it, I think it is helpful to keep it as-is to discern between normal strings and OID strings. Right now "_id" is the only key that uses this formatting.