### PR TITLE
Add working POST request and update architecture

### DIFF
--- a/src/cosi_db/controller/api.rs
+++ b/src/cosi_db/controller/api.rs
@@ -2,6 +2,7 @@
 use serde_json;
 
 // rocket
+use rocket::form::Form;
 use rocket::http::Status;
 use rocket::response::content::RawJson;
 use rocket::response::status::Custom;
@@ -17,19 +18,19 @@ use crate::cosi_db::model::common::Generator;
 use crate::{generate_generators, generate_pageable_getter, generate_pageable_inserter};
 
 // Address
-use crate::cosi_db::model::address::{Address, AddressForm};
+use crate::cosi_db::model::address::{Address, AddressImpl, AddressOptional};
 generate_generators! { Address }
 generate_pageable_getter! { Address }
 generate_pageable_inserter! { Address }
 
 // Person
-use crate::cosi_db::model::person::{Person, PersonForm};
+use crate::cosi_db::model::person::{Person, PersonImpl, PersonOptional};
 generate_generators! { Person }
 generate_pageable_getter! { Person }
 generate_pageable_inserter! { Person }
 
 // Household
-use crate::cosi_db::model::household::{Household, HouseholdForm};
+use crate::cosi_db::model::household::{Household, HouseholdImpl, HouseholdOptional};
 generate_generators! { Household }
 generate_pageable_getter! { Household }
 generate_pageable_inserter! { Household }

--- a/src/cosi_db/controller/common.rs
+++ b/src/cosi_db/controller/common.rs
@@ -85,7 +85,7 @@ macro_rules! generate_pageable_getter {
             $crate::with_builtin_macros::with_builtin!{
                 let $v_path = concat!("/get_", stringify!([<$T: lower>]), "?<page>&<search_query..>") in {
                     #[get($v_path)]
-                    pub async fn [<get_ $T:lower>](page: Option<u64>, search_query: [<$T Form>]) -> RawJson<String> {
+                    pub async fn [<get_ $T:lower>](page: Option<u64>, search_query: [<$T Optional>]) -> RawJson<String> {
                         let page = page.unwrap_or(0);
 
                         let col = $T::get_collection().await;
@@ -125,10 +125,11 @@ macro_rules! generate_pageable_inserter {
     ($T:ident) => {
         $crate::paste::paste! {
             $crate::with_builtin_macros::with_builtin!{
-                let $v_path = concat!("/insert_", stringify!([<$T: lower>]), "?<insert_query..>") in {
-                    #[get($v_path)]
-                    pub async fn [<insert_ $T:lower>](insert_query: [<$T Form>]) -> Custom<RawJson<String>> {
-                        let search_convert = $T::convert_form_insert(insert_query);
+                let $v_path = concat!("/insert_", stringify!([<$T: lower>])) in {
+                    #[post($v_path, data="<insert_query>")]
+                    pub async fn [<insert_ $T:lower>](insert_query: Form<[<$T Impl>]>) -> Custom<RawJson<String>> {
+                        let insert_query_obj = insert_query.into_inner();
+                        let search_convert = $T::convert_form_insert(insert_query_obj);
                         return match search_convert {
                             Ok(search_obj) => {
                                 // Query any search_queries

--- a/src/cosi_db/model/address.rs
+++ b/src/cosi_db/model/address.rs
@@ -26,7 +26,7 @@ pub struct Address {
 }
 
 #[derive(Clone, Debug, Deserialize, FromForm, Serialize)]
-pub struct AddressForm {
+pub struct AddressOptional {
     pub line_one: Option<String>,
     pub line_two: Option<String>,
     pub line_three: Option<String>,
@@ -36,7 +36,10 @@ pub struct AddressForm {
     pub county: Option<Option<String>>,
     pub country: Option<Option<String>>,
 }
-impl COSIForm for AddressForm {}
+
+pub type AddressImpl = Address;
+impl COSIForm for AddressImpl {}
+impl COSIForm for AddressOptional {}
 
 impl Default for Address {
     fn default() -> Self {
@@ -54,7 +57,7 @@ impl Default for Address {
 }
 
 #[async_trait]
-impl COSICollection<'_, Address, Address, AddressForm> for Address {
+impl COSICollection<'_, Address, AddressImpl, AddressOptional> for Address {
     fn get_table_name() -> String {
         return "address".to_string();
     }

--- a/src/cosi_db/model/common.rs
+++ b/src/cosi_db/model/common.rs
@@ -1,14 +1,69 @@
-use async_trait::async_trait;
-use mongodb::{
-    bson::to_document, bson::Bson, bson::Document, options::FindOptions, options::InsertOneOptions,
-};
+use mongodb::{options::FindOptions, options::InsertOneOptions};
+use rocket::async_trait;
+use rocket::data::ToByteUnit;
+use rocket::form::{DataField, FromFormField, ValueField};
+use std::str::FromStr;
+
+use mongodb::bson::{oid::ObjectId, to_document, Bson, Document};
 use mongodb::{Collection, Cursor};
 
 use futures::stream::{StreamExt, TryStreamExt};
 
 use crate::cosi_db::controller::common::get_connection;
 use crate::cosi_db::errors::{COSIError, COSIResult};
-use serde::{de::DeserializeOwned, Serialize};
+use serde::{de::DeserializeOwned, Deserialize, Serialize};
+
+#[derive(Clone, Debug, Serialize, Deserialize)]
+pub struct OID(pub ObjectId);
+
+impl OID {
+    pub fn vec_to_object_id(oid: &Vec<OID>) -> Vec<ObjectId> {
+        oid.iter().map(|x| x.0).collect()
+    }
+}
+
+impl Default for OID {
+    fn default() -> Self {
+        OID(ObjectId::default())
+    }
+}
+
+impl From<ObjectId> for OID {
+    fn from(oid: ObjectId) -> Self {
+        OID(oid)
+    }
+}
+
+impl From<OID> for ObjectId {
+    fn from(oid: OID) -> Self {
+        oid.0
+    }
+}
+
+#[rocket::async_trait]
+impl<'a> FromFormField<'a> for OID {
+    fn from_value(field: ValueField<'a>) -> rocket::form::Result<'a, Self> {
+        Ok(ObjectId::from_str(field.value).unwrap().into()) // TODO: Error handling.
+    }
+
+    async fn from_data(field: DataField<'a, '_>) -> rocket::form::Result<'a, Self> {
+        let limit = field
+            .request
+            .limits()
+            .get("_oid")
+            .unwrap_or(256_i32.kibibytes());
+        let bytes = field.data.open(limit).into_bytes().await?;
+        if !bytes.is_complete() {
+            Err((None, Some(limit)))?;
+        }
+
+        let bytes = bytes.into_inner();
+        let bytes = rocket::request::local_cache!(field.request, bytes);
+        Ok(ObjectId::from_str(std::str::from_utf8(bytes)?)
+            .unwrap()
+            .into()) // TODO: Error check.
+    }
+}
 
 #[async_trait]
 pub trait Generator<T> {
@@ -28,7 +83,7 @@ pub trait COSIForm {
             match v.1 {
                 Bson::Null => {
                     if strict {
-                        return Err(COSIError::msg(format! {"{} key missing.", v.0}));
+                        result.insert(v.0, v.1);
                     }
                 }
                 _ => {
@@ -62,8 +117,17 @@ pub trait COSIForm {
 pub trait COSICollection<'a, T, I, F>
 where
     for<'r> T: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + Sync + From<I> + 'r, // Base class
-    for<'r> I: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + Sync + From<T> + 'r,
-    for<'r> F: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + COSIForm + 'r,
+    for<'r> I: Clone
+        + Sized
+        + Serialize
+        + DeserializeOwned
+        + Unpin
+        + Send
+        + Sync
+        + From<T>
+        + COSIForm
+        + 'r,
+    for<'r> F: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + Sync + COSIForm + 'r,
 {
     fn get_table_name() -> String;
     async fn get_raw_document() -> Collection<Document> {
@@ -126,7 +190,7 @@ where
         return form_data.sanitize_query();
     }
 
-    fn convert_form_insert(form_data: F) -> COSIResult<Document> {
+    fn convert_form_insert(form_data: I) -> COSIResult<Document> {
         return form_data.sanitize_insert();
     }
 }

--- a/tests/household.test.js
+++ b/tests/household.test.js
@@ -3,34 +3,14 @@ import request from 'supertest';
 import { ALL_PAGEABLE_ENDPOINTS, ALL_GEN_ENDPOINTS } from "./endpoints.js";
 
 // Basic helpers
-function cosi_request() {
+function cosiRequest() {
     return request("127.0.0.1:8000");
 }
-
-function expectKeys(json_data, keys) {
-    expect(Object.keys(json_data)).toEqual(keys);
-}
-
-// Test setup
-beforeAll(async ()=> {
-    // Before tests begin, populate table with values.
-    let total_data_points_per_table = 200;
-    for (let endpoints of ALL_GEN_ENDPOINTS) {
-        let response = await cosi_request().get(`/${endpoints}/${total_data_points_per_table}`)
-                                           .expect(200)
-                                           .expect("Content-Type", /json/);
-
-        let json_data = JSON.parse(response.text);
-        expectKeys(json_data, ["total"]);
-        expect(json_data["total"]).toBe(total_data_points_per_table)
-    }
-});
 const endpoint = "get_household";
 
 // Testing
 describe("Test Root", () => {
     test("/ GET", async () => {
-        cosi_request().get(`/${endpoint}`).expect(200).expect("Content-Type", /json/);
+        cosiRequest().get(`/${endpoint}`).expect(200).expect("Content-Type", /json/);
     })
 });
-

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -169,7 +169,6 @@ describe("CRUD", () => {
                                         "country": "Middle Earth"
                                     });
 
-            console.log(JSON.parse(response.text));
             verifyData(response.text);
         });
     });

--- a/tests/main.test.js
+++ b/tests/main.test.js
@@ -3,127 +3,174 @@ import assert from 'assert';
 
 import { ALL_PAGEABLE_ENDPOINTS, ALL_GEN_ENDPOINTS } from "./endpoints.js";
 
-var total_datapoints_per_table = 200;
+var totalDatapointsPerTable = 200;
 
 // Basic helpers
-function cosi_request() {
+function cosiRequest() {
     return request("127.0.0.1:8000");
 }
 
-function expectKeys(json_data, keys) {
-    expect(Object.keys(json_data)).toEqual(keys);
+function expectKeys(jsonData, keys) {
+    expect(Object.keys(jsonData)).toEqual(keys);
 }
 
 // Test setup
 beforeAll(async ()=> {
     // Before tests begin, populate table with values.
-    for (let endpoints of ALL_GEN_ENDPOINTS) {
-        let response = await cosi_request().get(`/${endpoints}/${total_datapoints_per_table}`)
+    for (let endpoint of ALL_GEN_ENDPOINTS) {
+        let response = await cosiRequest().get(`/${endpoint}/${totalDatapointsPerTable}`)
                                            .expect(200)
                                            .expect("Content-Type", /json/);
 
-        let json_data = JSON.parse(response.text);
-        expectKeys(json_data, ["total"]);
-        expect(json_data["total"]).toBe(total_datapoints_per_table)
+        let jsonData = JSON.parse(response.text);
+        expectKeys(jsonData, ["total"]);
+        expect(jsonData["total"]).toBe(totalDatapointsPerTable)
     }
 });
 
 // Testing
 describe("Test Root", () => {
     test("/ GET", async () => {
-        cosi_request().get("/").expect(200);
+        cosiRequest().get("/").expect(200);
     })
 });
 
-describe("Verify Getters", () => {
+
+describe("CRUD", () => {
     // Check all basic GET endpoints.
     // Each get page should have max 100 datapoints.
-    const max_datapoints = 100;
-    const return_keys = [
-        "page",
-        "total_pages",
-        "data"
-    ];
-    for (let endpoint of ALL_PAGEABLE_ENDPOINTS) {
-        test(`/${endpoint} GET`, async () => {
-            // Basic endpoint response verification.
-            const response = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .query({page: 0})
-                                    .expect(200)
-                                    .expect("Content-Type", /json/);
+    describe("Verify Getters", () => {
+        const maxDatapoints = 100;
+        const returnKeys = [
+            "page",
+            "total_pages",
+            "data"
+        ];
+        for (let endpoint of ALL_PAGEABLE_ENDPOINTS) {
+            test(`/${endpoint} GET`, async () => {
+                // Basic endpoint response verification.
+                const response = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .query({page: 0})
+                                        .expect(200)
+                                        .expect("Content-Type", /json/);
+    
+                // Further data verification.
+                let jsonData = JSON.parse(response.text);
+                expectKeys(jsonData, returnKeys);
+                expect(Object.keys(jsonData["data"]).length).toBe(maxDatapoints);
+            });
+    
+            test(`/${endpoint} Empty page load`, async() => {
+                const allData = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .expect(200)
+                                        .query({page: Number.MAX_SAFE_INTEGER})
+                                        .expect("Content-Type", /json/);
+                let jsonData = JSON.parse(allData.text);
+                expect(Object.keys(jsonData["data"]).length).toBe(0);
+            });
+    
+            test(`/${endpoint} Invalid page load`, async() => {
+                const fakePages = ["cosi", "-1", "!@#$%^&*()-_+=`"];
+                for (const page of fakePages){
+                    const allData = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .query({page: `${page}`})
+                                        .expect(200)
+                                        .expect("Content-Type", /json/);
+                    let jsonData = JSON.parse(allData.text);
+                    expect(jsonData["page"]).toBe(0);
+                    expect(Object.keys(jsonData["data"]).length).toBe(maxDatapoints);
+                    expect(jsonData["total_pages"]).toBe(Math.ceil(totalDatapointsPerTable/maxDatapoints));
+                }
+            });
+    
+            test(`/${endpoint} Correct page count`, async() => {
+                const allData = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .expect(200)
+                                        .expect("Content-Type", /json/);
+                let jsonData = JSON.parse(allData.text);
+                let totalPages = jsonData["total_pages"];
+                expect(totalPages).toBe(Math.ceil(totalDatapointsPerTable/maxDatapoints));
+    
+            });
+    
+            test(`/${endpoint} No duplicate page data`, async() => {
+                let pages = [];
+                // Concatenate all data to single array
+                for(let page = 0; page < Math.ceil(totalDatapointsPerTable/maxDatapoints); page++){
+                    let request = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .query({page: `${page}`})
+                                        .expect(200)
+                                        .expect("Content-Type", /json/)
+                    let jsonData = JSON.parse(request.text);
+                    pages = pages.concat(Object.values(jsonData["data"]));
+                }
+                // Converting to a set will de-duplicate data. If there are no duplicates, the length
+                // of the set should the the same as the length of the array.
+                let page_set = new Set(pages);
+                expect(pages.length).toBe(page_set.size);
+    
+            });
+    
+            test(`/${endpoint} load < 100ms`, async() => {
+                // Assert that all tables can load data page in < 350ms
+                let start_time = Date.now();
+                // Exclude normal 200 and content asserts so they don't impact performance
+                const response = await cosiRequest()
+                                        .get(`/${endpoint}`)
+                                        .query({page: 0})
+                let endTime = Date.now();
+                expect(endTime - start_time).toBeLessThan(350);
+            });
+        }
+    });
 
-            // Further data verification.
-            let json_data = JSON.parse(response.text);
-            expectKeys(json_data, return_keys);
-            expect(Object.keys(json_data["data"]).length).toBe(max_datapoints);
-        });
+    // Insert after getters so it doesn't change the get count.
+    describe("Verify Setters", () => {
+        let verifyData = (data) => {
+            let jData = JSON.parse(data);
+            expectKeys(jData, ["$oid"]);
+        };
 
-        test(`/${endpoint} Empty page load`, async() => {
-            const all_data = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .expect(200)
-                                    .query({page: Number.MAX_SAFE_INTEGER})
-                                    .expect("Content-Type", /json/);
-            let json_data = JSON.parse(all_data.text);
-            expect(Object.keys(json_data["data"]).length).toBe(0);
-        });
-
-        test(`/${endpoint} Invalid page load`, async() => {
-            const fake_pages = ["cosi", "-1", "!@#$%^&*()-_+=`"];
-            for (const page of fake_pages){
-                const all_data = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .query({page: `${page}`})
-                                    .expect(200)
-                                    .expect("Content-Type", /json/);
-                let json_data = JSON.parse(all_data.text);
-                expect(json_data["page"]).toBe(0);
-                expect(Object.keys(json_data["data"]).length).toBe(max_datapoints);
-                expect(json_data["total_pages"]).toBe(Math.ceil(total_datapoints_per_table/max_datapoints));
-            }
-        });
-
-        test(`/${endpoint} Correct page count`, async() => {
-            const all_data = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .expect(200)
-                                    .expect("Content-Type", /json/);
-            let json_data = JSON.parse(all_data.text);
-            let total_pages = json_data["total_pages"];
-            expect(total_pages).toBe(Math.ceil(total_datapoints_per_table/max_datapoints));
-
-        });
-
-        test(`/${endpoint} No duplicate page data`, async() => {
-            let pages = [];
-            // Concatenate all data to single array
-            for(let page = 0; page < Math.ceil(total_datapoints_per_table/max_datapoints); page++){
-                let request = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .query({page: `${page}`})
+        const endpointPerson = "insert_person";
+        test(`/${endpointPerson} POST`, async () => {
+            const response = await cosiRequest()
+                                    .post(`/${endpointPerson}`)
+                                    .type("form")
+                                    .send({
+                                        "first_name": "mario",
+                                        "middle_name": "plumber",
+                                        "last_name": "mario",
+                                        "dob": "1985-09-13",
+                                        "age": 20,
+                                        "sex": "Male"})
                                     .expect(200)
                                     .expect("Content-Type", /json/)
-                let json_data = JSON.parse(request.text);
-                pages = pages.concat(Object.values(json_data["data"]));
-            }
-            // Converting to a set will de-duplicate data. If there are no duplicates, the length
-            // of the set should the the same as the length of the array.
-            let page_set = new Set(pages);
-            expect(pages.length).toBe(page_set.size);
 
+            verifyData(response.text);
         });
 
-        test(`/${endpoint} load < 100ms`, async() => {
-            // Assert that all tables can load data page in < 350ms
-            let start_time = Date.now();
-            // Exclude normal 200 and content asserts so they don't impact performance
-            const response = await cosi_request()
-                                    .get(`/${endpoint}`)
-                                    .query({page: 0})
-            let end_time = Date.now();
-            expect(end_time - start_time).toBeLessThan(350);
+        const endpointAddress = "insert_address";
+        test(`/${endpointAddress} POST`, async () => {
+            const response = await cosiRequest()
+                                    .post(`/${endpointAddress}`)
+                                    .type("form")
+                                    .send({
+                                        "line_one": "1337 Street",
+                                        "line_two": "gura-a",
+                                        "line_three": "Your time to shine",
+                                        "city": "Iselgard",
+                                        "region": "Gondor",
+                                        "postal_code": "2468",
+                                        "country": "Middle Earth"
+                                    });
+
+            console.log(JSON.parse(response.text));
+            verifyData(response.text);
         });
-    }
+    });
 });
-


### PR DESCRIPTION
This one is a big change with a lot of things I am not a big fan of but it tries to fix a problem with our architecture brought forth by constraints introduced by Rocket.rs parsing structure. First things first, here are the changes.

## Changes

* Changes `insert_xxx` endpoints to POST Requests
* Add basic sanity test for POST requests.
  * Household endpoint not implemented since it is a bit involved with foreign keys.
* Modifies backend so that GET requests with optional queries use `<T>Optional`
* Modifies backend so that POST requests use `<T>Impl`
* Adds wrapper type `OID(ObjectId)` to interop with MongoDB ObjectId and allow Rocket.rs to parse directly from params to OID.

## Why the Changes?

### The Need for Struct, StructImpl, and StructOptional

Rocket.rs 0.5-rc allows for parsing from URI to object directly with de-serialization behavior via `FromForm`. However, for Rocket.rs to understand whether or not a URI token has optional parameters, types must be wrapped with `Option`.

#### Constraints of GETTER

Now consider the two use-cases of POST and GET requests for our `insert_xxx` and `get_xxx` endpoints respectfully.
GET allows the following:

`get_example/?page=0&*`

Where `*` is any number of optional key parameters defined by the table. So you end up something like this:

```rust
MyExampleOptional {
   a: Option<String>,
   b: Option<String>
}
```

Which can later be parsed to check if we want to query this value in the database. If it exists, serialize a `bson::Document` to query `MongoDB`. However if it doesn't exist, ignore the key entirely.

Note how if we allow for nullable values in the database, we endup with the following:

```rust
MyStructOptional {
   a: Option<String>,
   opt: Option<Option<String>>
}
```

A double Option wrapper needs to occur. One for denoting whether or not a value is provided. Then furthermore, whether or not to set the value to null in the database!

#### Constraints of INSERT

Now consider POST or insert operations. We need all required values to exist. Option implies that a value is nullable in the database. If we were to use `MyStructOptional` from before (so we can reuse code) we end up telling Rocket.rs that all parameters are optional! Which is not what we want. Instead we want:

```rust
MyStructImpl {
   a: String,
   opt: Option<String>
}
```

Basically, POST requires the **database implementation** of the struct where `Option` represents literal nullable entries. Whereas GET requires entries all wrapped with `Option`.

If somehow we can define a helper macro such that:

> Functor(MyStructImpl) -> MyStructOptional

This should reduce code-bloat. Other than that, I don't see a way around this.

#### Impact to COSICollection

The biggest trade-off is probably `COSICollection` which now require three large templated references. This can probably be reduced with Macros. Each of the templates: T, I, and F represents different representations of the same type and provides constraints to convert from one to another.

**Oh the joys of explicit trait constraints**

```rust
pub trait COSICollection<'a, T, I, F>
where
    for<'r> T: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + Sync + From<I> + 'r, // Base class
    for<'r> I: Clone
        + Sized
        + Serialize
        + DeserializeOwned
        + Unpin
        + Send
        + Sync
        + From<T>
        + COSIForm
        + 'r,
    for<'r> F: Clone + Sized + Serialize + DeserializeOwned + Unpin + Send + Sync + COSIForm + 'r,
```

### The Need for OID

OID is a simple wrapper around `ObjectId` so that we can use `HouseholdImpl` as-is from POST requests without having to change `persons: Vec<ObjectId>` and `address: ObjectId` into type Strings. Holding `ObjectId` directly allows for easier transformations.

Newtype is necessary here so we can implement a `From` trait for `ObjectId` to string. Since we don't `ObjectId`, we have to use our own type. See: https://rust-unofficial.github.io/patterns/patterns/behavioural/newtype.html
